### PR TITLE
Integrate encoding fix, query usability, and SQL credential override into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,15 @@ curl http://localhost:8080/metrics
 ## Available MCP Tools
 The server exposes these tools to MCP clients:
 
-### 1. `execute_sql(sql, format="table")`
-Execute SELECT queries (or write operations if enabled)
+### 1. `execute_sql(sql, format="table", timeout=None, max_rows=None)`
+Execute SELECT queries (or write operations if enabled).
+- `format`: `"table"`, `"json"` or `"csv"`.
+- `timeout`: per-query timeout (seconds), overrides `MSSQL_QUERY_TIMEOUT` for slow queries.
+- `max_rows`: per-query row cap, overrides `MAX_ROWS_PER_QUERY`.
 ```
-Input: "SELECT * FROM users LIMIT 10"
-Output: ASCII table or JSON
+Input: "SELECT TOP 10 * FROM users", format="json"
+Output: JSON rows + summary; truncation is flagged explicitly.
+        Write statements return the affected-row count.
 ```
 
 ### 2. `list_schemas()`
@@ -97,21 +101,28 @@ Input: schema="dbo"
 Output: JSON with detailed column info
 ```
 
-### 5. `get_database_info()`
+### 5. `describe_table(table)`
+Describe a single table: columns, types, nullability, primary keys, descriptions
+```
+Input: table="dbo.users"  (schema prefix optional)
+Output: JSON column metadata for that one table
+```
+
+### 6. `get_database_info()`
 Get server/database metadata
 ```
 Input: (none)
 Output: Database name, version, machine name
 ```
 
-### 6. `get_policy_info()`
+### 7. `get_policy_info()`
 Get current security policy settings
 ```
 Input: (none)
 Output: Policy details (allowed operations, limits)
 ```
 
-### 7. `check_db_connection()`
+### 8. `check_db_connection()`
 Health check for database connectivity
 ```
 Input: (none)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,17 @@ ENABLE_WRITES=true ADMIN_CONFIRM=secret python -m mssql_mcp.cli
 MSSQL_QUERY_TIMEOUT=120 python -m mssql_mcp.cli
 ```
 
+### Fix Garbled Non-ASCII Characters (accents, etc.)
+Results are decoded using explicit encodings. The defaults work for most SQL Server
+setups (NVARCHAR is UTF-16LE, VARCHAR is read as UTF-8). If `VARCHAR` columns use a
+legacy code-page collation, override the narrow encoding:
+```bash
+# e.g. Central-European legacy VARCHAR data
+MSSQL_ENCODING=cp1250 python -m mssql_mcp.cli
+```
+- `MSSQL_ENCODING` (default `utf-8`) — narrow `SQL_CHAR`/`VARCHAR` columns and parameter binding
+- `MSSQL_WIDE_ENCODING` (default `utf-16-le`) — wide `SQL_WCHAR`/`NVARCHAR` columns
+
 ### Run Multiple Instances
 ```bash
 python -m mssql_mcp.cli --transport http --bind 127.0.0.1:8080

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ legacy code-page collation, override the narrow encoding:
 # e.g. Central-European legacy VARCHAR data
 MSSQL_ENCODING=cp1250 python -m mssql_mcp.cli
 ```
-- `MSSQL_ENCODING` (default `utf-8`) — narrow `SQL_CHAR`/`VARCHAR` columns and parameter binding
-- `MSSQL_WIDE_ENCODING` (default `utf-16-le`) — wide `SQL_WCHAR`/`NVARCHAR` columns
+- `MSSQL_ENCODING` (default `utf-8`) — decoding of narrow `SQL_CHAR`/`VARCHAR` columns
+- `MSSQL_WIDE_ENCODING` (default `utf-16-le`) — wide `SQL_WCHAR`/`NVARCHAR` decoding **and** the query/parameter send encoding (SQL Server expects UTF-16LE; sending UTF-8 corrupts accented literals in queries)
 
 ### Run Multiple Instances
 ```bash

--- a/README.md
+++ b/README.md
@@ -182,6 +182,25 @@ LOG_LEVEL=DEBUG python -m mssql_mcp.cli
 ```bash
 ENABLE_WRITES=true ADMIN_CONFIRM=secret python -m mssql_mcp.cli
 ```
+> The app-level `ENABLE_WRITES` switch is only the first line of defense. The
+> ultimate authority is the permissions of the SQL login you connect as — see
+> credential override below.
+
+### Use a Specific SQL Login (credential override)
+Each deployment can run under its own SQL login without editing the base
+connection string. `MSSQL_USER` / `MSSQL_PASSWORD` take precedence over any
+`UID`/`PWD` embedded in `MSSQL_CONNECTION_STRING`:
+```bash
+# Base string holds only driver/server/database; identity comes from these:
+MSSQL_USER=reporting_ro MSSQL_PASSWORD=secret python -m mssql_mcp.cli
+```
+- `MSSQL_USER`, `MSSQL_PASSWORD` — override the SQL credentials (ideal for secrets).
+- `MSSQL_TRUSTED_CONNECTION=true` — use Windows/Integrated auth instead (ignores user/password).
+
+Because the connected login's own permissions govern access, connecting with a
+read-only login enforces read-only **at the database level**, regardless of
+`ENABLE_WRITES`. Conversely, allowing writes requires both `ENABLE_WRITES=true`
+and a login that has write permission.
 
 ### Increase Query Timeout
 ```bash

--- a/src/mssql_mcp/config.py
+++ b/src/mssql_mcp/config.py
@@ -19,6 +19,14 @@ class Settings(BaseSettings):
     MSSQL_QUERY_TIMEOUT: int = 30  # seconds
     MSSQL_MAX_POOL_SIZE: int = 10
 
+    # Character encoding for pyodbc (fixes garbled non-ASCII output, e.g. accented text).
+    # MSSQL_ENCODING covers narrow SQL_CHAR/VARCHAR columns and parameter binding;
+    # MSSQL_WIDE_ENCODING covers wide SQL_WCHAR/NVARCHAR columns (SQL Server sends these
+    # as UTF-16LE). Override MSSQL_ENCODING (e.g. "cp1250") if VARCHAR data uses a legacy
+    # code-page collation.
+    MSSQL_ENCODING: str = "utf-8"
+    MSSQL_WIDE_ENCODING: str = "utf-16-le"
+
     # Security & safety
     READ_ONLY: bool = True
     ENABLE_WRITES: bool = False

--- a/src/mssql_mcp/config.py
+++ b/src/mssql_mcp/config.py
@@ -19,11 +19,12 @@ class Settings(BaseSettings):
     MSSQL_QUERY_TIMEOUT: int = 30  # seconds
     MSSQL_MAX_POOL_SIZE: int = 10
 
-    # Character encoding for pyodbc (fixes garbled non-ASCII output, e.g. accented text).
-    # MSSQL_ENCODING covers narrow SQL_CHAR/VARCHAR columns and parameter binding;
-    # MSSQL_WIDE_ENCODING covers wide SQL_WCHAR/NVARCHAR columns (SQL Server sends these
-    # as UTF-16LE). Override MSSQL_ENCODING (e.g. "cp1250") if VARCHAR data uses a legacy
-    # code-page collation.
+    # Character encoding for pyodbc (fixes garbled non-ASCII, e.g. accented text).
+    # MSSQL_WIDE_ENCODING is used for wide SQL_WCHAR/NVARCHAR decoding AND for the
+    # query/parameter send encoding — SQL Server expects UTF-16LE, so leave this at
+    # the default unless you know otherwise. MSSQL_ENCODING covers narrow
+    # SQL_CHAR/VARCHAR decoding; override it (e.g. "cp1250") if VARCHAR data uses a
+    # legacy code-page collation.
     MSSQL_ENCODING: str = "utf-8"
     MSSQL_WIDE_ENCODING: str = "utf-16-le"
 

--- a/src/mssql_mcp/config.py
+++ b/src/mssql_mcp/config.py
@@ -14,10 +14,21 @@ class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
 
     # Database connection
-    MSSQL_CONNECTION_STRING: str 
+    MSSQL_CONNECTION_STRING: str
     MSSQL_CONNECTION_TIMEOUT: int = 30  # seconds
     MSSQL_QUERY_TIMEOUT: int = 30  # seconds
     MSSQL_MAX_POOL_SIZE: int = 10
+
+    # Optional credential override. When set, these take precedence over any
+    # UID/PWD embedded in MSSQL_CONNECTION_STRING, letting each deployment run
+    # under its own SQL login (and thus its own read/write permissions) without
+    # editing the base connection string. Leave unset to use the connection
+    # string as-is.
+    MSSQL_USER: Optional[str] = None
+    MSSQL_PASSWORD: Optional[str] = None
+    # Windows/Integrated authentication. True forces Trusted_Connection=yes
+    # (ignores user/password); False forces SQL auth; None leaves it untouched.
+    MSSQL_TRUSTED_CONNECTION: Optional[bool] = None
 
     # Security & safety
     READ_ONLY: bool = True

--- a/src/mssql_mcp/db.py
+++ b/src/mssql_mcp/db.py
@@ -47,8 +47,13 @@ def get_connection():
             autocommit=False,
             timeout=settings.MSSQL_CONNECTION_TIMEOUT,
         )
-        # Set connection options
-        conn.setencoding(encoding="utf-8")
+        # Configure character encoding so non-ASCII data (e.g. accented text) is
+        # decoded correctly. Without explicit setdecoding, pyodbc falls back to
+        # platform defaults, which can garble VARCHAR/NVARCHAR results.
+        conn.setencoding(encoding=settings.MSSQL_ENCODING)
+        conn.setdecoding(pyodbc.SQL_CHAR, encoding=settings.MSSQL_ENCODING)
+        conn.setdecoding(pyodbc.SQL_WCHAR, encoding=settings.MSSQL_WIDE_ENCODING)
+        conn.setdecoding(pyodbc.SQL_WMETADATA, encoding=settings.MSSQL_WIDE_ENCODING)
         yield conn
     except pyodbc.Error as e:
         logger.exception("Database connection error: %s", e)

--- a/src/mssql_mcp/db.py
+++ b/src/mssql_mcp/db.py
@@ -8,12 +8,29 @@ Uses pyodbc with connection pooling and thread-safe execution via asyncio.to_thr
 import asyncio
 import logging
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from typing import List, Tuple, Iterator, Optional, Any
 import pyodbc
 
 from .config import settings
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class QueryResult:
+    """Result of a query execution.
+
+    Attributes:
+        columns: Column names (empty for statements with no result set).
+        rows: Result rows, capped at max_rows.
+        truncated: True if more rows were available than max_rows.
+        rowcount: Affected-row count for write statements; -1 when not applicable.
+    """
+    columns: List[str] = field(default_factory=list)
+    rows: List[Tuple[Any, ...]] = field(default_factory=list)
+    truncated: bool = False
+    rowcount: int = -1
 
 # Enable ODBC connection pooling for better resource management
 pyodbc.pooling = True
@@ -32,6 +49,28 @@ class QueryTimeoutError(DatabaseError):
 class ConnectionError(DatabaseError):
     """Database connection error."""
     pass
+
+
+def _fetch_rows(cursor, max_rows: int, batch_size: int = 1000) -> Tuple[List[Tuple[Any, ...]], bool]:
+    """Fetch up to max_rows rows from a cursor, reporting truncation.
+
+    Allows the row count to exceed max_rows before trimming so that a result
+    of exactly max_rows rows is not mislabelled as truncated.
+
+    Returns (rows, truncated).
+    """
+    rows: List[Tuple[Any, ...]] = []
+    truncated = False
+    while True:
+        batch = cursor.fetchmany(batch_size)
+        if not batch:
+            break
+        rows.extend(batch)
+        if len(rows) > max_rows:
+            rows = rows[:max_rows]
+            truncated = True
+            break
+    return rows, truncated
 
 
 @contextmanager
@@ -66,20 +105,21 @@ async def execute_query(
     params: Tuple = (),
     timeout: Optional[int] = None,
     max_rows: Optional[int] = None,
-) -> Tuple[List[str], List[Tuple[Any, ...]]]:
+) -> QueryResult:
     """
-    Execute a SQL SELECT statement asynchronously.
+    Execute a SQL statement asynchronously.
 
-    Runs in a thread to avoid blocking the event loop. Returns columns and rows.
+    Runs in a thread to avoid blocking the event loop. Handles both queries that
+    return a result set (SELECT) and statements that do not (INSERT/UPDATE/DELETE).
 
     Args:
-        sql: SQL query string (should be SELECT)
+        sql: SQL statement to execute
         params: Query parameters (for parameterized queries)
         timeout: Query timeout in seconds (defaults to MSSQL_QUERY_TIMEOUT)
         max_rows: Maximum rows to return (defaults to MAX_ROWS_PER_QUERY)
 
     Returns:
-        Tuple of (column_names, rows)
+        QueryResult with columns, rows, truncated flag and affected rowcount.
 
     Raises:
         QueryTimeoutError: If query exceeds timeout
@@ -90,7 +130,7 @@ async def execute_query(
     if max_rows is None:
         max_rows = settings.MAX_ROWS_PER_QUERY
 
-    def _sync_execute() -> Tuple[List[str], List[Tuple[Any, ...]]]:
+    def _sync_execute() -> QueryResult:
         """Synchronous query execution in thread."""
         with get_connection() as conn:
             cursor = conn.cursor()
@@ -99,23 +139,17 @@ async def execute_query(
                 # Extract column names from cursor description
                 columns = [desc[0] for desc in cursor.description] if cursor.description else []
 
-                # Fetch rows with batch processing for memory efficiency
-                rows: List[Tuple[Any, ...]] = []
                 if columns:
-                    batch_size = 1000
-                    while True:
-                        batch = cursor.fetchmany(batch_size)
-                        if not batch:
-                            break
-                        rows.extend(batch)
-                        if len(rows) >= max_rows:
-                            rows = rows[:max_rows]
-                            break
+                    # Fetch rows with batch processing for memory efficiency,
+                    # flagging truncation when more than max_rows are available.
+                    rows, truncated = _fetch_rows(cursor, max_rows)
+                    return QueryResult(columns=columns, rows=rows, truncated=truncated)
                 else:
-                    # No columns means no result set (USE statement)
+                    # No result set: write statement (INSERT/UPDATE/DELETE) or USE.
+                    # Capture affected rows and commit the transaction.
+                    rowcount = cursor.rowcount
                     conn.commit()
-
-                return columns, rows
+                    return QueryResult(columns=[], rows=[], rowcount=rowcount)
             except pyodbc.Error as e:
                 logger.exception("Query execution error: %s", e)
                 raise DatabaseError(f"Query execution failed: {e}") from e
@@ -140,7 +174,7 @@ async def execute_query(
         raise DatabaseError(f"Unexpected error: {e}") from e
 
 
-async def execute_schema_query(sql: str, timeout: Optional[int] = None) -> Tuple[List[str], List[Tuple[Any, ...]]]:
+async def execute_schema_query(sql: str, timeout: Optional[int] = None) -> QueryResult:
     """
     Execute a schema/metadata query with relaxed row limits.
     Used for list_tables, list_schemas, schema_discovery.
@@ -162,9 +196,9 @@ async def get_database_info() -> dict:
             SERVERPROPERTY('MachineName') as machine_name,
             SERVERPROPERTY('InstanceName') as instance_name
         """
-        cols, rows = await execute_schema_query(sql)
-        if rows:
-            return dict(zip(cols, rows[0]))
+        result = await execute_schema_query(sql)
+        if result.rows:
+            return dict(zip(result.columns, result.rows[0]))
         return {}
     except Exception as e:
         logger.exception("Error fetching database info: %s", e)
@@ -176,7 +210,7 @@ async def check_connection() -> bool:
     Test database connectivity.
     """
     try:
-        cols, rows = await execute_query("SELECT 1 as test", timeout=5)
+        await execute_query("SELECT 1 as test", timeout=5)
         return True
     except Exception as e:
         logger.error("Connection check failed: %s", e)

--- a/src/mssql_mcp/db.py
+++ b/src/mssql_mcp/db.py
@@ -34,6 +34,61 @@ class ConnectionError(DatabaseError):
     pass
 
 
+def _quote_odbc_value(value: str) -> str:
+    """Wrap an ODBC connection value in braces if it contains special chars."""
+    if value and (";" in value or "{" in value or "}" in value or value.strip() != value):
+        return "{" + value.replace("}", "}}") + "}"
+    return value
+
+
+def build_connection_string() -> str:
+    """Build the effective connection string, applying optional credential overrides.
+
+    MSSQL_USER / MSSQL_PASSWORD (and MSSQL_TRUSTED_CONNECTION) take precedence over
+    UID/PWD embedded in MSSQL_CONNECTION_STRING, so a deployment can run under its
+    own SQL login without editing the base connection string. Only the credential
+    keys being overridden are replaced; everything else is preserved.
+    """
+    base = settings.MSSQL_CONNECTION_STRING
+    user = settings.MSSQL_USER
+    password = settings.MSSQL_PASSWORD
+    trusted = settings.MSSQL_TRUSTED_CONNECTION
+
+    # No overrides configured -> use the connection string as-is.
+    if not user and not password and trusted is None:
+        return base
+
+    # Determine which credential keys to drop from the base string.
+    drop = set()
+    if trusted is True:
+        drop |= {"uid", "pwd", "user id", "password", "trusted_connection"}
+    elif trusted is False:
+        drop |= {"trusted_connection"}
+    if user:
+        drop |= {"uid", "user id"}
+    if password:
+        drop |= {"pwd", "password"}
+
+    kept = []
+    for part in base.split(";"):
+        if not part.strip():
+            continue
+        key = part.split("=", 1)[0].strip().lower()
+        if key in drop:
+            continue
+        kept.append(part.strip())
+
+    if trusted is True:
+        kept.append("Trusted_Connection=yes")
+    else:
+        if user:
+            kept.append(f"UID={_quote_odbc_value(user)}")
+        if password:
+            kept.append(f"PWD={_quote_odbc_value(password)}")
+
+    return ";".join(kept) + ";"
+
+
 @contextmanager
 def get_connection():
     """
@@ -43,7 +98,7 @@ def get_connection():
     conn = None
     try:
         conn = pyodbc.connect(
-            settings.MSSQL_CONNECTION_STRING,
+            build_connection_string(),
             autocommit=False,
             timeout=settings.MSSQL_CONNECTION_TIMEOUT,
         )

--- a/src/mssql_mcp/db.py
+++ b/src/mssql_mcp/db.py
@@ -142,9 +142,11 @@ def get_connection():
             timeout=settings.MSSQL_CONNECTION_TIMEOUT,
         )
         # Configure character encoding so non-ASCII data (e.g. accented text) is
-        # decoded correctly. Without explicit setdecoding, pyodbc falls back to
-        # platform defaults, which can garble VARCHAR/NVARCHAR results.
-        conn.setencoding(encoding=settings.MSSQL_ENCODING)
+        # sent and decoded correctly. SQL Server expects the query/parameter text
+        # as UTF-16LE (setencoding); sending UTF-8 corrupts non-ASCII literals in
+        # queries. Result decoding is set explicitly too, since pyodbc's platform
+        # defaults can otherwise garble VARCHAR/NVARCHAR values.
+        conn.setencoding(encoding=settings.MSSQL_WIDE_ENCODING)
         conn.setdecoding(pyodbc.SQL_CHAR, encoding=settings.MSSQL_ENCODING)
         conn.setdecoding(pyodbc.SQL_WCHAR, encoding=settings.MSSQL_WIDE_ENCODING)
         conn.setdecoding(pyodbc.SQL_WMETADATA, encoding=settings.MSSQL_WIDE_ENCODING)

--- a/src/mssql_mcp/logging_config.py
+++ b/src/mssql_mcp/logging_config.py
@@ -24,6 +24,7 @@ class SensitiveDataFilter(logging.Filter):
         "pwd",
         "connection_string",
         "MSSQL_CONNECTION_STRING",
+        "MSSQL_PASSWORD",
         "auth_token",
         "token",
         "api_key",
@@ -35,11 +36,11 @@ class SensitiveDataFilter(logging.Filter):
         if hasattr(record, "msg") and isinstance(record.msg, str):
             for key in self.SENSITIVE_KEYS:
                 if key.lower() in record.msg.lower():
-                    # Redact the message
-                    record.msg = record.msg.replace(
-                        settings.MSSQL_CONNECTION_STRING,
-                        "***REDACTED***"
-                    )
+                    # Redact known secret values from the message.
+                    for secret in (settings.MSSQL_CONNECTION_STRING, settings.MSSQL_PASSWORD):
+                        if secret:
+                            record.msg = record.msg.replace(secret, "***REDACTED***")
+                    break
         return True
 
 

--- a/src/mssql_mcp/policy.py
+++ b/src/mssql_mcp/policy.py
@@ -181,6 +181,7 @@ def explain_policy() -> dict:
             "list_schemas",
             "list_tables",
             "schema_discovery",
+            "describe_table",
             "get_database_info",
         ],
         "banned_patterns": READ_ONLY_BANNED_PATTERNS if mode == QueryMode.READ_ONLY else [],

--- a/src/mssql_mcp/tools.py
+++ b/src/mssql_mcp/tools.py
@@ -26,19 +26,31 @@ mcp = FastMCP("mssql-mcp")
 async def execute_sql(
     sql: str,
     format: str = "table",
+    timeout: Optional[int] = None,
+    max_rows: Optional[int] = None,
 ) -> str:
     """
-    Execute a SQL query against the SQL Server database.
+    Execute a SQL statement against the SQL Server database.
 
-    This tool executes SELECT queries by default (read-only mode). If write operations
-    are enabled in config, INSERT/UPDATE/DELETE are allowed.
+    SELECT queries run in read-only mode by default. Write operations
+    (INSERT/UPDATE/DELETE) only succeed if the server is started with
+    ENABLE_WRITES=true and a matching ADMIN_CONFIRM token; otherwise they are
+    rejected by the policy engine. For writes, the affected-row count is returned.
 
     Args:
-        sql: SQL query to execute (typically SELECT)
-        format: Output format - 'table', 'json', or 'csv' (default: 'table')
+        sql: SQL statement to execute.
+        format: Output format for result sets - 'table', 'json', or 'csv'
+            (default: 'table'). Use 'json' for the most machine-readable output.
+        timeout: Per-query timeout in seconds. Overrides the server default
+            (MSSQL_QUERY_TIMEOUT) for this call only — raise it for slow,
+            complex queries such as large JOINs or CROSS APPLY.
+        max_rows: Maximum rows to return for this call. Overrides the server
+            default (MAX_ROWS_PER_QUERY). The output flags when results are
+            truncated.
 
     Returns:
-        Formatted query results as string
+        Formatted query results as string, followed by a summary line. For write
+        statements, a confirmation with the affected-row count.
     """
     client_id = "unknown"  # Could be extracted from request context in production
     tool_name = "execute_sql"
@@ -54,20 +66,28 @@ async def execute_sql(
     # Execute query with metrics tracking
     with MetricsContext(tool_name) as metrics:
         try:
-            columns, rows = await execute_query(sql)
-            metrics.set_rows(len(rows))
+            res = await execute_query(sql, timeout=timeout, max_rows=max_rows)
+            metrics.set_rows(len(res.rows))
+
+            # Write statement / no result set: report affected rows.
+            if not res.columns:
+                if res.rowcount >= 0:
+                    return f"OK: {res.rowcount} row(s) affected."
+                return "OK: statement executed (no result set)."
 
             # Format output
             if format.lower() == "json":
-                result = format_json(columns, rows)
+                result = format_json(res.columns, res.rows)
             elif format.lower() == "csv":
                 from .utils import format_csv
-                result = format_csv(columns, rows)
+                result = format_csv(res.columns, res.rows)
             else:  # table (default)
-                result = format_table(columns, rows) if columns else "(no result)"
+                result = format_table(res.columns, res.rows)
 
-            # Add summary
-            summary = result_summary(columns, rows)
+            # Add summary, flagging truncation explicitly so it is never silent.
+            summary = result_summary(res.columns, res.rows)
+            if res.truncated:
+                summary += " — TRUNCATED (more rows available; raise max_rows to see them)"
             return f"{result}\n\n[{summary}]"
 
         except Exception as e:
@@ -95,14 +115,14 @@ async def list_schemas() -> str:
             FROM sys.schemas
             ORDER BY name
             """
-            columns, rows = await execute_schema_query(sql)
-            metrics.set_rows(len(rows))
+            res = await execute_schema_query(sql)
+            metrics.set_rows(len(res.rows))
 
-            if not rows:
+            if not res.rows:
                 return "No schemas found."
 
             # Format simple list
-            schema_names = [row[1] for row in rows]
+            schema_names = [row[1] for row in res.rows]
             return "\n".join(f"  - {name}" for name in schema_names)
 
         except Exception as e:
@@ -150,15 +170,15 @@ async def list_tables(schema: Optional[str] = None, limit: int = 200) -> str:
             ORDER BY s.name, t.name
             """
 
-            columns, rows = await execute_schema_query(sql)
-            metrics.set_rows(len(rows))
+            res = await execute_schema_query(sql)
+            metrics.set_rows(len(res.rows))
 
-            if not rows:
+            if not res.rows:
                 return "No tables found."
 
             # Format results
-            result = format_table(columns, rows)
-            return f"{result}\n\n[{len(rows)} table(s)]"
+            result = format_table(res.columns, res.rows)
+            return f"{result}\n\n[{len(res.rows)} table(s)]"
 
         except Exception as e:
             logger.exception("list_tables failed")
@@ -209,19 +229,92 @@ async def schema_discovery(schema: Optional[str] = None) -> str:
             ORDER BY schema_name, table_name, column_name
             """
 
-            columns, rows = await execute_schema_query(sql, timeout=60)
-            metrics.set_rows(len(rows))
+            res = await execute_schema_query(sql, timeout=60)
+            metrics.set_rows(len(res.rows))
 
-            if not rows:
+            if not res.rows:
                 return "No schema information found."
 
             # Convert to JSON structure
             from .utils import format_json
-            result = format_json(columns, rows)
+            result = format_json(res.columns, res.rows)
             return result
 
         except Exception as e:
             logger.exception("schema_discovery failed")
+            return f"ERROR: {type(e).__name__}: {str(e)}"
+
+
+@mcp.tool()
+async def describe_table(table: str) -> str:
+    """
+    Describe a single table's structure: columns, data types, length,
+    nullability, primary-key membership, and column descriptions.
+
+    A focused alternative to schema_discovery when you only need one table.
+
+    Args:
+        table: Table name, optionally schema-qualified (e.g. 'dbo.users' or
+            'users'). Without a schema prefix, all schemas are matched.
+
+    Returns:
+        JSON-formatted column metadata, or a not-found message.
+    """
+    tool_name = "describe_table"
+    from .utils import escape_sql_string, format_json
+
+    # Split optional schema qualifier ('schema.table').
+    if "." in table:
+        schema_name, table_name = table.split(".", 1)
+    else:
+        schema_name, table_name = None, table
+
+    with MetricsContext(tool_name) as metrics:
+        try:
+            filters = [f"t.name = {escape_sql_string(table_name)}"]
+            if schema_name:
+                filters.append(f"s.name = {escape_sql_string(schema_name)}")
+            where = " AND ".join(filters)
+
+            sql = f"""
+            SELECT
+                s.name AS schema_name,
+                t.name AS table_name,
+                c.column_id,
+                c.name AS column_name,
+                ty.name AS data_type,
+                c.max_length,
+                c.precision,
+                c.scale,
+                c.is_nullable,
+                CASE WHEN pk.column_id IS NOT NULL THEN 1 ELSE 0 END AS is_primary_key,
+                ep.value AS description
+            FROM sys.tables t
+            INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+            INNER JOIN sys.columns c ON t.object_id = c.object_id
+            INNER JOIN sys.types ty ON c.user_type_id = ty.user_type_id
+            LEFT JOIN (
+                SELECT ic.object_id, ic.column_id
+                FROM sys.index_columns ic
+                INNER JOIN sys.indexes i
+                    ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+                WHERE i.is_primary_key = 1
+            ) pk ON pk.object_id = c.object_id AND pk.column_id = c.column_id
+            LEFT JOIN sys.extended_properties ep
+                ON ep.major_id = c.object_id AND ep.minor_id = c.column_id
+            WHERE {where}
+            ORDER BY s.name, t.name, c.column_id
+            """
+            res = await execute_schema_query(sql)
+            metrics.set_rows(len(res.rows))
+
+            if not res.rows:
+                return f"Table not found: {table}"
+
+            return format_json(res.columns, res.rows)
+
+        except Exception as e:
+            logger.exception("describe_table failed")
             return f"ERROR: {type(e).__name__}: {str(e)}"
 
 


### PR DESCRIPTION
Brings the fork's `main` up to date with the deployed feature set (also open as upstream PRs #4/#5/#7):

- **Encoding**: explicit pyodbc decoding + UTF-16LE send so Hungarian/accented text works in both directions.
- **Usability**: per-query `timeout`/`max_rows`, explicit truncation flag, write affected-row count, `describe_table`, typed `QueryResult`.
- **Credentials**: optional `MSSQL_USER`/`MSSQL_PASSWORD`/`MSSQL_TRUSTED_CONNECTION` override.

This is the `deploy` branch currently running on PDAPP2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)