### PR TITLE
Per-request SQL credentials via MCP headers

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "mssql-mcp": {
+      "type": "http",
+      "url": "http://pdapp2.inhat.hu:8006/mcp"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -219,6 +219,33 @@ read-only login enforces read-only **at the database level**, regardless of
 `ENABLE_WRITES`. Conversely, allowing writes requires both `ENABLE_WRITES=true`
 and a login that has write permission.
 
+#### Per-request credentials (remote clients, HTTP transport)
+A remote client can authenticate as **its own** SQL login for the duration of a
+request by sending credentials as HTTP headers — no server reconfiguration, and
+it overrides the server's default identity just for that client. Set them in the
+MCP client config, e.g. `.mcp.json`:
+```json
+{
+  "mcpServers": {
+    "mssql-mcp": {
+      "type": "http",
+      "url": "http://your-host:8080/mcp",
+      "headers": {
+        "X-MSSQL-User": "your_login",
+        "X-MSSQL-Password": "your_password"
+      }
+    }
+  }
+}
+```
+Headers (all optional): `X-MSSQL-User`, `X-MSSQL-Password`,
+`X-MSSQL-Trusted-Connection` (`true`/`false`). When absent, the server's default
+credentials are used. Precedence: request headers → server `MSSQL_USER`/… →
+`UID`/`PWD` in `MSSQL_CONNECTION_STRING`.
+
+> Security: credentials travel in headers, so use HTTPS (or a trusted network).
+> Access is still bounded by that login's own SQL Server permissions.
+
 ### Increase Query Timeout
 ```bash
 MSSQL_QUERY_TIMEOUT=120 python -m mssql_mcp.cli

--- a/mssql-mcp.client-config.md
+++ b/mssql-mcp.client-config.md
@@ -1,16 +1,15 @@
 # mssql-mcp — client configuration
 
-The MCP server runs on PDAPP2 and connects to SQL Server as the **`mate`** login.
-Point any MCP-capable app at the HTTP endpoint below — no SQL credentials are
-needed on the client side (the server holds them).
+The MCP server runs on PDAPP2. Point any MCP-capable app at the HTTP endpoint.
 
 - **Endpoint:** `http://pdapp2.inhat.hu:8006/mcp`
 - **Transport:** streamable HTTP
-- **Effective SQL identity:** `mate`
+- **Default SQL identity:** `srv_vambery` (scoped service account) — used when you
+  send no credential headers.
 - Requires network access to `pdapp2.inhat.hu:8006`.
 
-## Claude Code (project or user scope)
-`.mcp.json` (already added to this repo root):
+## Option A — use the default identity (`srv_vambery`)
+No credentials needed on the client. `.mcp.json` (already in this repo root):
 ```json
 {
   "mcpServers": {
@@ -18,27 +17,42 @@ needed on the client side (the server holds them).
   }
 }
 ```
-Or add it via CLI:
+
+## Option B — authenticate as your own login (e.g. `mate`)
+Send your SQL credentials as headers in the client config. This overrides the
+server default **only for your connection** — no server change needed. Fill in
+your own password; do NOT commit a file containing a real password.
+```json
+{
+  "mcpServers": {
+    "mssql-mcp-mate": {
+      "type": "http",
+      "url": "http://pdapp2.inhat.hu:8006/mcp",
+      "headers": {
+        "X-MSSQL-User": "mate",
+        "X-MSSQL-Password": "<your-mate-password>"
+      }
+    }
+  }
+}
 ```
-claude mcp add --transport http mssql-mcp http://pdapp2.inhat.hu:8006/mcp
-```
+Optional header: `X-MSSQL-Trusted-Connection: true` for Windows/Integrated auth
+(ignores user/password). Works from any MCP client that supports custom headers
+(Claude Code, Claude Desktop, generic HTTP MCP clients) — reuse the same block.
+
+> Security: the endpoint is plain HTTP, so credentials travel unencrypted on the
+> network. Prefer a trusted network / put HTTPS in front for production use.
+> Your access is bounded by that login's own SQL Server permissions.
 
 ## Claude Desktop
-Add to `claude_desktop_config.json`
-(Windows: `%APPDATA%\Claude\claude_desktop_config.json`):
-```json
-{
-  "mcpServers": {
-    "mssql-mcp": { "type": "http", "url": "http://pdapp2.inhat.hu:8006/mcp" }
-  }
-}
-```
+Add the same `mcpServers` block to `claude_desktop_config.json`
+(Windows: `%APPDATA%\Claude\claude_desktop_config.json`).
 
-## Generic MCP client
-Use transport = HTTP (streamable), URL = `http://pdapp2.inhat.hu:8006/mcp`.
-
-Health/config without an MCP client: `curl http://pdapp2.inhat.hu:8006/info`.
+## Verify
+- Config/health without a client: `curl http://pdapp2.inhat.hu:8006/info`.
+- Which login am I? call `execute_sql` with `SELECT SUSER_SNAME()`.
 
 Tools exposed: `execute_sql`, `describe_table`, `list_tables`, `list_schemas`,
 `schema_discovery`, `get_database_info`, `get_policy_info`, `check_db_connection`.
-Writes are currently enabled. See the `mssql-mcp-usage` skill for conventions.
+Writes are enabled (bounded by your login's permissions). See the
+`mssql-mcp-usage` skill for conventions.

--- a/mssql-mcp.client-config.md
+++ b/mssql-mcp.client-config.md
@@ -1,0 +1,44 @@
+# mssql-mcp — client configuration
+
+The MCP server runs on PDAPP2 and connects to SQL Server as the **`mate`** login.
+Point any MCP-capable app at the HTTP endpoint below — no SQL credentials are
+needed on the client side (the server holds them).
+
+- **Endpoint:** `http://pdapp2.inhat.hu:8006/mcp`
+- **Transport:** streamable HTTP
+- **Effective SQL identity:** `mate`
+- Requires network access to `pdapp2.inhat.hu:8006`.
+
+## Claude Code (project or user scope)
+`.mcp.json` (already added to this repo root):
+```json
+{
+  "mcpServers": {
+    "mssql-mcp": { "type": "http", "url": "http://pdapp2.inhat.hu:8006/mcp" }
+  }
+}
+```
+Or add it via CLI:
+```
+claude mcp add --transport http mssql-mcp http://pdapp2.inhat.hu:8006/mcp
+```
+
+## Claude Desktop
+Add to `claude_desktop_config.json`
+(Windows: `%APPDATA%\Claude\claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "mssql-mcp": { "type": "http", "url": "http://pdapp2.inhat.hu:8006/mcp" }
+  }
+}
+```
+
+## Generic MCP client
+Use transport = HTTP (streamable), URL = `http://pdapp2.inhat.hu:8006/mcp`.
+
+Health/config without an MCP client: `curl http://pdapp2.inhat.hu:8006/info`.
+
+Tools exposed: `execute_sql`, `describe_table`, `list_tables`, `list_schemas`,
+`schema_discovery`, `get_database_info`, `get_policy_info`, `check_db_connection`.
+Writes are currently enabled. See the `mssql-mcp-usage` skill for conventions.

--- a/src/mssql_mcp/db.py
+++ b/src/mssql_mcp/db.py
@@ -8,13 +8,48 @@ Uses pyodbc with connection pooling and thread-safe execution via asyncio.to_thr
 import asyncio
 import logging
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import List, Tuple, Iterator, Optional, Any
+from typing import List, Tuple, Iterator, Optional, Any, Dict
 import pyodbc
 
 from .config import settings
 
 logger = logging.getLogger(__name__)
+
+# Per-request SQL credential override (set from MCP request headers). When set,
+# it takes precedence over the server's own MSSQL_USER/MSSQL_PASSWORD settings for
+# the duration of one request, letting a remote client authenticate as its own SQL
+# login. Copied into worker threads by asyncio.to_thread, so it reaches the sync
+# DB code. None means "use server defaults".
+_request_credentials: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "mssql_request_credentials", default=None
+)
+
+
+@contextmanager
+def request_credentials(user: Optional[str] = None, password: Optional[str] = None,
+                        trusted: Optional[bool] = None):
+    """Bind per-request SQL credentials for the enclosed call.
+
+    A no-op when all three are unset, so callers can wrap unconditionally.
+    """
+    if not user and not password and trusted is None:
+        yield
+        return
+    token = _request_credentials.set({"user": user, "password": password, "trusted": trusted})
+    try:
+        yield
+    finally:
+        _request_credentials.reset(token)
+
+
+def _effective_credentials() -> Tuple[Optional[str], Optional[str], Optional[bool]]:
+    """Return (user, password, trusted): per-request override if set, else settings."""
+    req = _request_credentials.get()
+    if req is not None:
+        return req.get("user"), req.get("password"), req.get("trusted")
+    return settings.MSSQL_USER, settings.MSSQL_PASSWORD, settings.MSSQL_TRUSTED_CONNECTION
 
 
 @dataclass
@@ -83,15 +118,15 @@ def _quote_odbc_value(value: str) -> str:
 def build_connection_string() -> str:
     """Build the effective connection string, applying optional credential overrides.
 
-    MSSQL_USER / MSSQL_PASSWORD (and MSSQL_TRUSTED_CONNECTION) take precedence over
-    UID/PWD embedded in MSSQL_CONNECTION_STRING, so a deployment can run under its
-    own SQL login without editing the base connection string. Only the credential
-    keys being overridden are replaced; everything else is preserved.
+    Credentials come from the per-request override if one is bound (see
+    request_credentials), otherwise from MSSQL_USER / MSSQL_PASSWORD /
+    MSSQL_TRUSTED_CONNECTION. They take precedence over UID/PWD embedded in
+    MSSQL_CONNECTION_STRING, so a deployment (or an individual remote client) can
+    run under its own SQL login without editing the base connection string. Only
+    the credential keys being overridden are replaced; everything else is preserved.
     """
     base = settings.MSSQL_CONNECTION_STRING
-    user = settings.MSSQL_USER
-    password = settings.MSSQL_PASSWORD
-    trusted = settings.MSSQL_TRUSTED_CONNECTION
+    user, password, trusted = _effective_credentials()
 
     # No overrides configured -> use the connection string as-is.
     if not user and not password and trusted is None:

--- a/src/mssql_mcp/tools.py
+++ b/src/mssql_mcp/tools.py
@@ -9,17 +9,55 @@ import logging
 import time
 from typing import Optional, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP, Context
 from mcp.server.transport_security import TransportSecuritySettings
 
 from .config import settings
 
-from .db import execute_query, execute_schema_query, get_database_info as fetch_database_info, check_connection, DatabaseError
+from .db import execute_query, execute_schema_query, get_database_info as fetch_database_info, check_connection, DatabaseError, request_credentials
 from .policy import validate_with_audit, QueryMode, get_query_mode, explain_policy
 from .metrics import MetricsContext, record_query_blocked
 from .utils import format_table, format_json, result_summary
 
 logger = logging.getLogger(__name__)
+
+
+# HTTP headers a remote client may send (e.g. in its MCP config) to authenticate
+# as its own SQL login for the duration of a request, overriding the server's
+# default credentials. Passwords travel in headers, so use HTTPS / a trusted
+# network in production.
+_HDR_USER = "X-MSSQL-User"
+_HDR_PASSWORD = "X-MSSQL-Password"
+_HDR_TRUSTED = "X-MSSQL-Trusted-Connection"
+
+
+def _creds_from_ctx(ctx: Optional[Context]) -> dict:
+    """Extract optional per-request SQL credentials from the MCP request headers.
+
+    Returns a dict suitable for request_credentials(**...); empty when none are
+    provided (e.g. stdio transport, or a client that sends no credential headers).
+    """
+    if ctx is None:
+        return {}
+    try:
+        request = ctx.request_context.request
+    except Exception:
+        return {}
+    headers = getattr(request, "headers", None)
+    if not headers:
+        return {}
+
+    creds: dict = {}
+    user = headers.get(_HDR_USER)
+    password = headers.get(_HDR_PASSWORD)
+    trusted_raw = headers.get(_HDR_TRUSTED)
+    if user:
+        creds["user"] = user
+    if password:
+        creds["password"] = password
+    if trusted_raw is not None:
+        creds["trusted"] = trusted_raw.strip().lower() in ("1", "true", "yes", "on")
+    return creds
 
 def _get_transport_security():
     """Configure transport security based on ALLOWED_HOST setting."""
@@ -46,6 +84,7 @@ async def execute_sql(
     format: str = "table",
     timeout: Optional[int] = None,
     max_rows: Optional[int] = None,
+    ctx: Optional[Context] = None,
 ) -> str:
     """
     Execute a SQL statement against the SQL Server database.
@@ -84,7 +123,8 @@ async def execute_sql(
     # Execute query with metrics tracking
     with MetricsContext(tool_name) as metrics:
         try:
-            res = await execute_query(sql, timeout=timeout, max_rows=max_rows)
+            with request_credentials(**_creds_from_ctx(ctx)):
+                res = await execute_query(sql, timeout=timeout, max_rows=max_rows)
             metrics.set_rows(len(res.rows))
 
             # Write statement / no result set: report affected rows.
@@ -114,7 +154,7 @@ async def execute_sql(
 
 
 @mcp.tool()
-async def list_schemas() -> str:
+async def list_schemas(ctx: Optional[Context] = None) -> str:
     """
     List all schemas in the current database.
 
@@ -133,7 +173,8 @@ async def list_schemas() -> str:
             FROM sys.schemas
             ORDER BY name
             """
-            res = await execute_schema_query(sql)
+            with request_credentials(**_creds_from_ctx(ctx)):
+                res = await execute_schema_query(sql)
             metrics.set_rows(len(res.rows))
 
             if not res.rows:
@@ -149,7 +190,7 @@ async def list_schemas() -> str:
 
 
 @mcp.tool()
-async def list_tables(schema: Optional[str] = None, limit: int = 200) -> str:
+async def list_tables(schema: Optional[str] = None, limit: int = 200, ctx: Optional[Context] = None) -> str:
     """
     List tables in the database, optionally filtered by schema.
 
@@ -188,7 +229,8 @@ async def list_tables(schema: Optional[str] = None, limit: int = 200) -> str:
             ORDER BY s.name, t.name
             """
 
-            res = await execute_schema_query(sql)
+            with request_credentials(**_creds_from_ctx(ctx)):
+                res = await execute_schema_query(sql)
             metrics.set_rows(len(res.rows))
 
             if not res.rows:
@@ -204,7 +246,7 @@ async def list_tables(schema: Optional[str] = None, limit: int = 200) -> str:
 
 
 @mcp.tool()
-async def schema_discovery(schema: Optional[str] = None) -> str:
+async def schema_discovery(schema: Optional[str] = None, ctx: Optional[Context] = None) -> str:
     """
     Discover schema information: tables, columns, types, and constraints.
 
@@ -247,7 +289,8 @@ async def schema_discovery(schema: Optional[str] = None) -> str:
             ORDER BY schema_name, table_name, column_name
             """
 
-            res = await execute_schema_query(sql, timeout=60)
+            with request_credentials(**_creds_from_ctx(ctx)):
+                res = await execute_schema_query(sql, timeout=60)
             metrics.set_rows(len(res.rows))
 
             if not res.rows:
@@ -264,7 +307,7 @@ async def schema_discovery(schema: Optional[str] = None) -> str:
 
 
 @mcp.tool()
-async def describe_table(table: str) -> str:
+async def describe_table(table: str, ctx: Optional[Context] = None) -> str:
     """
     Describe a single table's structure: columns, data types, length,
     nullability, primary-key membership, and column descriptions.
@@ -323,7 +366,8 @@ async def describe_table(table: str) -> str:
             WHERE {where}
             ORDER BY s.name, t.name, c.column_id
             """
-            res = await execute_schema_query(sql)
+            with request_credentials(**_creds_from_ctx(ctx)):
+                res = await execute_schema_query(sql)
             metrics.set_rows(len(res.rows))
 
             if not res.rows:
@@ -337,7 +381,7 @@ async def describe_table(table: str) -> str:
 
 
 @mcp.tool()
-async def get_database_info() -> str:
+async def get_database_info(ctx: Optional[Context] = None) -> str:
     """
     Get general information about the database and server.
 
@@ -348,7 +392,8 @@ async def get_database_info() -> str:
 
     with MetricsContext(tool_name) as metrics:
         try:
-            info = await fetch_database_info()
+            with request_credentials(**_creds_from_ctx(ctx)):
+                info = await fetch_database_info()
             metrics.set_rows(1)
 
             from .utils import format_json
@@ -388,7 +433,7 @@ async def get_policy_info() -> str:
 
 
 @mcp.tool()
-async def check_db_connection() -> str:
+async def check_db_connection(ctx: Optional[Context] = None) -> str:
     """
     Check if the database connection is active and healthy.
 
@@ -399,7 +444,8 @@ async def check_db_connection() -> str:
 
     with MetricsContext(tool_name) as metrics:
         try:
-            is_connected = await check_connection()
+            with request_credentials(**_creds_from_ctx(ctx)):
+                is_connected = await check_connection()
             metrics.set_rows(1)
 
             if is_connected:


### PR DESCRIPTION
Adds per-request credential override (X-MSSQL-User/Password/Trusted headers) so a remote client can authenticate as its own SQL login, plus client-config docs. Deployed and verified on PDAPP2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)